### PR TITLE
fix(system-test): flaky HMAC keys test

### DIFF
--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2954,6 +2954,9 @@ describe('storage', () => {
 
     before(async () => {
       await deleteStaleHmacKeys(SERVICE_ACCOUNT, HMAC_PROJECT!);
+      if (SECOND_SERVICE_ACCOUNT) {
+        await deleteStaleHmacKeys(SECOND_SERVICE_ACCOUNT, HMAC_PROJECT!);
+      }
     });
 
     it('should create an HMAC key for a service account', async () => {

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -2952,14 +2952,6 @@ describe('storage', () => {
 
     let accessId: string;
 
-    before(async () => {
-      await deleteHmacKeys(SERVICE_ACCOUNT, HMAC_PROJECT!);
-    });
-
-    after(async () => {
-      await deleteHmacKeys(SERVICE_ACCOUNT, HMAC_PROJECT!);
-    });
-
     it('should create an HMAC key for a service account', async () => {
       const [hmacKey, secret] = await storage.createHmacKey(SERVICE_ACCOUNT, {
         projectId: HMAC_PROJECT,

--- a/system-test/storage.ts
+++ b/system-test/storage.ts
@@ -3021,16 +3021,25 @@ describe('storage', () => {
     });
 
     describe('second service account', () => {
+      let accessId: string;
+
       before(function () {
         if (!SECOND_SERVICE_ACCOUNT) {
           this.skip();
         }
       });
 
+      after(async () => {
+        const hmacKey = storage.hmacKey(accessId, {projectId: HMAC_PROJECT});
+        await hmacKey.setMetadata({state: 'INACTIVE'});
+        await hmacKey.delete();
+      });
+
       it('should create key for a second service account', async () => {
-        await storage.createHmacKey(SECOND_SERVICE_ACCOUNT!, {
+        const [hmacKey] = await storage.createHmacKey(SECOND_SERVICE_ACCOUNT!, {
           projectId: HMAC_PROJECT,
         });
+        accessId = hmacKey.id!;
       });
 
       it('get HMAC keys for both service accounts', async () => {


### PR DESCRIPTION
`HMAC keys` test it self is creating the HMAC key and deletes the newly created key, we don't need to delete it in `before` and `after` hook.

`deleteHmacKeys` is deleting all the keys in project. While multiple build runs concurrently on CI there is a possibility that one is trying to get metadata at the same time another build deleted that key.